### PR TITLE
Add Rust library to the list of LanguageTool libraries

### DIFF
--- a/public-http-api.md
+++ b/public-http-api.md
@@ -41,3 +41,4 @@ When using it, please keep the following rules in mind:
 * Java: LanguageTool comes with [RemoteLanguageTool](https://languagetool.org/development/api/org/languagetool/remote/RemoteLanguageTool.html)
   in the [languagetool-http-client](https://search.maven.org/search?q=a:languagetool-http-client) module
 * Python: [pyLanguagetool](https://github.com/Findus23/pyLanguagetool)
+* Rust: [LanguageTool-Rust](https://github.com/jeertmans/languagetool-rust)


### PR DESCRIPTION
Hello,

*I hope this is not too much of self-promotion*, but I recently worked a lot on a Rust library that aims to provide correct and safe bindings for the LanguageTool server API.

I think the library is now mature enough to be shared and, as I saw that your shared libraries from in other languages [on this page](https://dev.languagetool.org/public-http-api.html), I propose adding it to the list.

Likewise, I know my work is very recent and not used by many people, but I hope it will help the Rust community to integrate LanguageTool in their future projects.

Kind regards,

Jérome