### PR TITLE
[pt] Add Portuguese documentation

### DIFF
--- a/index.md
+++ b/index.md
@@ -51,3 +51,12 @@
 
 * [How to make a LanguageTool release](/how-to-make-a-languagetool-release), including actions for feature freeze
 * [How to add a new committer](/how-to-add-a-new-committer)
+
+#### Language-specific development
+
+##### Portuguese
+
+* [Observações gerais](pt/overview)
+* [Mensagens](/pt/messages)
+* [Regras](/pt/rules)
+* [Git](pt/git)

--- a/pt/git.md
+++ b/pt/git.md
@@ -40,6 +40,7 @@ Maus exemplos seriam: `maria_22_de_abril`, `regras`.
 Dentro do possível, mantenha seus *commits* bem descritos:
 - comece todos as suas mensagens de *commit* com a tag `[pt]`;
 - prefira escrevê-las em inglês;
-- a primeira linha da sua mensagem não deve ultrapassar 50 caracteres.
+- a primeira linha da sua mensagem não deve ultrapassar 50 caracteres;
+- a não ser que suas mudanças sejam gerais (ou seja, se apliquem a várias regras), busque pôr o nome da regra na mensagem.
 
-O adágio "*commit early, commit often*" só se aplica ao seu trabalho **local**.
+O adágio "*commit early, commit often*" só se aplica ao seu trabalho **local**. Ao criar um *pull request*, o ideal é que ele seja composto de poucos *commits* razoavelmente completos. Prefira fazer *squash* se você tiver muitos *commits* com mensagens do tipo `"[pt] Fix error"`, `"[pt] Add antipattern"`.

--- a/pt/git.md
+++ b/pt/git.md
@@ -40,7 +40,7 @@ Maus exemplos seriam: `maria_22_de_abril`, `regras`.
 Use [estas diretrizes](https://cbea.ms/git-commit/) (em inglês).
 
 Dentro do possível, mantenha seus *commits* bem descritos:
-- comece todos as suas mensagens de *commit* com a tag `[pt]`;
+- comece todas as suas mensagens de *commit* com a tag `[pt]`;
 - escreva-as em inglês;
 - a primeira linha da sua mensagem não deve ultrapassar 50 caracteres;
 - a não ser que suas mudanças sejam gerais (ou seja, se apliquem a várias regras), busque pôr o nome da regra na primeira linha da mensagem.

--- a/pt/git.md
+++ b/pt/git.md
@@ -1,0 +1,45 @@
+# Git
+
+O projeto é opensource, mas isso não quer dizer que vale tudo!
+
+## Abra *pull requests*
+
+**Especialmente** se você está contribuindo pela primeira vez, pedimos que você abra um *pull request* para que a comunidade do LanguageTool possa dar uma olhada no seu trabalho.
+
+Novos *pull requests* para o português devem, na medida do possível...
+- ... ser independentes e autônomos (*self-contained*) – ou seja, evite *pull requests* com várias mudanças desconexas;
+- ... ser descritos e documentados **em inglês**;
+- ... conter a tag `[pt]` no título do *pull request*, p. ex.: `[pt] Add grammar rule PREPOSICAO_DEPOIS_DE_ADVERBIO`;
+- ... conter a etiqueta `Portuguese`;
+- ... conter uma breve explicação do porquê das suas mudanças.
+
+Para que seu *pull request* seja considerado aceitável, ele deverá ter:
+- recebido no mínimo uma revisão positiva, ou seja, ter sido aprovado por alguém;
+- passado em todos os testes no nosso Circle CI.
+
+Uma vez que for aceito, você pode dar *merge* no seu próprio *pull request*. Se o seu PR contiver mais do que um *commit*, prefira a opção [*merge with squash*](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#squashing-your-merge-commits) para manter nossa história o mais limpa possível.
+
+## *Branching policy*
+
+Se possível, pedimos que os nomes das suas *branches* sigam o formato `pt/$domain/$change`, onde:
+- `$domain` corresponde ao conteúdo da sua mudança *sensu lato* – por exemplo, se estiver fazendo mudanças em regras de gramática, pode escrever aqui `grammar`; se forem regras de estilo, `style`; se estiver alterando [regras de ortografia](/hunspell-support), pode escrever `dict`;
+- `$change` corresponde ao conteúdo da sua mudança *sensu stricto*; pode ser o nome da nova regra, uma descrição concisa de sua contribuição, o código do *GitHub issue* ao qual sua mudança se refere, etc.
+
+Pedimos que o `$domain` seja escrito em inglês, mas a designação da sua mudança pode ser em português (se for o caso, busque evitar acentos, til, ou cedilha).
+
+Um bom exemplo de um nome de *branch* seria, por exemplo, `pt/grammar/subjuntivo_sem_conjuncao`.
+
+Os seguintes dados não precisam ser postos no nome da sua *branch*:
+- o seu nome;
+- a data.
+
+Maus exemplos seriam: `maria_22_de_abril`, `regras`.
+
+## [Mensagens de *commit*](https://xkcd.com/1296/)
+
+Dentro do possível, mantenha seus *commits* bem descritos:
+- comece todos as suas mensagens de *commit* com a tag `[pt]`;
+- prefira escrevê-las em inglês;
+- a primeira linha da sua mensagem não deve ultrapassar 50 caracteres.
+
+O adágio "*commit early, commit often*" só se aplica ao seu trabalho **local**.

--- a/pt/git.md
+++ b/pt/git.md
@@ -37,10 +37,12 @@ Maus exemplos seriam: `maria_22_de_abril`, `regras`.
 
 ## [Mensagens de *commit*](https://xkcd.com/1296/)
 
+Use [estas diretrizes](https://cbea.ms/git-commit/) (em inglês).
+
 Dentro do possível, mantenha seus *commits* bem descritos:
 - comece todos as suas mensagens de *commit* com a tag `[pt]`;
-- prefira escrevê-las em inglês;
+- escreva-as em inglês;
 - a primeira linha da sua mensagem não deve ultrapassar 50 caracteres;
-- a não ser que suas mudanças sejam gerais (ou seja, se apliquem a várias regras), busque pôr o nome da regra na mensagem.
+- a não ser que suas mudanças sejam gerais (ou seja, se apliquem a várias regras), busque pôr o nome da regra na primeira linha da mensagem.
 
 O adágio "*commit early, commit often*" só se aplica ao seu trabalho **local**. Ao criar um *pull request*, o ideal é que ele seja composto de poucos *commits* razoavelmente completos. Prefira fazer *squash* se você tiver muitos *commits* com mensagens do tipo `"[pt] Fix error"`, `"[pt] Add antipattern"`.

--- a/pt/messages.md
+++ b/pt/messages.md
@@ -1,0 +1,76 @@
+# Mensagens
+
+Ao escrever regras, nós também precisamos redigir as **mensagens** que as acompanham. Por exemplo:
+
+```xml
+<rule id="ERRO_DE_CRASE" name="Erro de crase">
+    <!-- lógica da regra, etc etc -->
+    <message>Possível erro de crase detectado. Considere substituir por <suggestion>à</suggestion>.</message>
+</rule>
+```
+
+## Princípios
+
+O objetivo do LanguageTool não é apenas consertar erros. Uma das ideias por trás do LT é **ajudar** ao usuário a escrever melhor.
+
+Com isto em vista, as mensagens do LanguageTool devem ser:
+
+* **informativas**: sempre que possível, forneça ao usuário uma explicação acerca de qual regra gramatical foi violada;
+* **amigáveis**: evite simplesmente dizer 'está errado' – dê ao usuário o benefício da dúvida;
+* **contextualizadas**: algumas regras só se aplicam em determinados contextos (por exemplo, as regras de estilo) – quando for o caso, informe ao usuário;
+* **neutras quanto ao dialeto** (na medida do possível): as regras do português **geral** (ou seja, os arquivos encontrados diretamente sob `pt`) não devem soar estranhas a nenhum lusófono, não importa de onde vem; se não for possível, é capaz que você esteja tentando criar uma regra para uma variedade específica do português (e.g. `pt-BR` ou `pt-PT`).
+* obedecer ao **Acordo Ortográfico de 1990**.
+
+## Entidades XML
+
+Para conferir ainda mais consistência às nossas mensagens, alguns fragmentos que se repetem frequentemente foram extraídos para arquivos `.ent`. Esses arquivos se encontram no diretório `resource/entities`. No caso das mensagens, o arquivo utilizado é `messages.ent`. Em vez de repetir a mesma sequência de palavras, prefira usar uma entidade XML.
+
+Ao invés de:
+
+```xml
+<rule id="ERRO_DE_ESTILO_1" name="Erro de estilo 1">
+    <!-- lógica da regra, etc etc -->
+    <message>Em contextos profissionais, evite usar o verbo &quot;verbar&quot;.</message>
+</rule>
+
+
+<rule id="ERRO_DE_ESTILO_2" name="Erro de estilo 2">
+    <!-- lógica da regra, etc etc -->
+    <message>Em contextos profissionais, prefira o adjetivo &quot;lindo&quot;.</message>
+</rule>
+```
+
+Prefira:
+
+No arquivo `resource/pt/entities/messages.ent`:
+
+```xml
+<!ENTITY professional_intro "Em contextos profissionais">
+```
+
+```xml
+<rule id="ERRO_DE_ESTILO_1" name="Erro de estilo 1">
+    <!-- lógica da regra, etc etc -->
+    <message>&professional_intro;, evite usar o verbo &quot;verbar&quot;.</message>
+</rule>
+
+
+<rule id="ERRO_DE_ESTILO_2" name="Erro de estilo 2">
+    <!-- lógica da regra, etc etc -->
+    <message>&professional_intro;, prefira o adjetivo &quot;lindo&quot;.</message>
+</rule>
+```
+
+## Aspas
+
+Para evitar problemas com diferenças entre o uso de aspas em padrões diferentes, prefira usar `&quot;` no lugar de aspas literais (p. ex. `"`).
+
+## Nomenclatura
+
+Algumas decisões são arbitrárias. Nossa intenção é registrá-las nesta página para que ninguém fique surpreso quando alguém lhe pedir que troque uma palavra por um sinônimo.
+
+|👎 NÃO USE 👎|👍 USE 👍|
+|---|---|
+|~~nome~~|substantivo|
+|~~conjuntivo~~|subjuntivo|
+

--- a/pt/overview.md
+++ b/pt/overview.md
@@ -1,0 +1,8 @@
+# Observações gerais
+
+Some intro nonsense, glad to see you, etc.
+
+## Dialetos
+
+Some platitudes about how we value all dialects but pt-BR is more important.
+

--- a/pt/overview.md
+++ b/pt/overview.md
@@ -1,8 +1,29 @@
 # Observações gerais
 
-Some intro nonsense, glad to see you, etc.
+✨ 🇧🇷 🇵🇹 🇦🇴 🇲🇿 🇸🇹 🇨🇻 🇹🇱 🇲🇴 ✨
+
+Bem-vindo à página do Português!
+
+Se você está lendo esta página, é bem possível que você esteja considerando fazer contribuições ao módulo português do LanguageTool – o que nos alegra muito!
+
+Esperamos que as informações aqui te ajudem a contribuir da maneira mais eficaz possível. Se estiver faltando algo, ou se algo não estiver claro, não hesite em registrar um *issue*.
 
 ## Dialetos
 
-Some platitudes about how we value all dialects but pt-BR is more important.
+Em primeiro lugar – nós sabemos que o português é uma língua *global* falada em vários continentes, com dialetos diferentes, cada um com histórias, dinâmicas e peculiaridades próprias.
 
+É capaz de você já ter percebido que quem escreveu este artigo é um falante do português do Brasil... Como essa é a variedade com o maior número de falantes, a equipe interna do LanguageTool para português é composta por brasileiros e, via de regra, esse é o dialeto que priorizamos para desenvolvimento interno. Mas **todos** têm a possibilidade de contribuir, não importa o dialeto.
+
+Existem dois níveis de contribuição:
+- `pt`: regras que se aplicam (ao menos em teoria!) a **todos** os dialetos do português;
+    - por exemplo, não há nenhum padrão do português no qual o plural de *tubarão* seja \**tubarães*..!
+- `pt-XX`: aqui, o `XX` se refere a um país (de acordo com o alpha-2 da [ISO 3166](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes));
+    - por exemplo, no Brasil se usa _detectar_, enquanto que, em Portugal, prefere-se _detetar_ – `pt-BR` considerará _detetar_ incorreto e `pt-PT` recomendará aos nossos usuários que evitem _detectar_.
+
+Se você observar a estrutura das pastas dentro do diretório `pt`, você vai ver pastas como `pt-BR`, `pt-PT`, `pt-AO`, etc. Essas pastas contêm regras específicas aos dialetos que as nomeiam.
+
+### Dialetos e estilo
+
+O LanguageTool não é apenas uma ferramenta de correção gramatical e ortográfica. Nós também oferecemos regras de **estilo** para que nossos usuários escrevam de maneira que condiga melhor com o tipo de texto que estejam compondo. Não se trata de regras rígidas, e sim de sugestões.
+
+Em dialetos diferentes, essas sugestões podem ser bem diferentes. O que soa formal em Portugal pode ser coloquial em Moçambique, e vice-versa. Procure pensar bem em suas regras de estilo antes de propô-las para que não o LanguageTool não acabe por recomendar estruturas que *piorem* um texto em alguns dialetos enquanto o melhore em outros.

--- a/pt/rules.md
+++ b/pt/rules.md
@@ -1,0 +1,3 @@
+# Regras
+
+mais uma

--- a/pt/rules.md
+++ b/pt/rules.md
@@ -1,3 +1,25 @@
 # Regras
 
-mais uma
+Nossa ideia é que contribuintes *opensource* tenham suficiente flexibilidade para sugerir novas regras sem grandes obstáculos de natureza técnica, mas sem pôr em risco a qualidade e consistência das nossas regras. Tendo isso em vista, desenvolvemos as diretrizes nesta página.
+
+## *Rule IDs*
+Os IDs das nossas regras *atuais* não são lá muito coesos. Temos regras com IDs em inglês, outras em português, e ainda outras com as duas línguas misturadas. No momento da redação destas diretrizes, não temos a menor intenção de renomeá-las todas para que combinem com o novo esquema. As regras *legacy* ficam como estão no presente momento, mas isso não quer dizer que não possamos revisar como as nomeamos **a partir de agora**.
+
+### Esquema
+
+O ID de uma regra deve...
+
+- ser escrito **em português**;
+    - sabemos que é uma prática um tanto peculiar, mas isso facilita a identificação dessas regras nos *logs* internos;
+    - se estiver propondo uma regra válida para todos os dialetos do português, na medida do possível evite palavras com grafias que variam de acordo com dialeto – se não for possível, pedimos que use a grafia usada **no Brasil**;
+- ser escrito **em maiúsculas** – ou seja, `NOVA_REGRA`;
+    - cada elemento deve ser separado por um *underscore*, ou seja, `_`;
+- ser informativo – evite IDs arbitrários como `REGRA_PLURAL_2`, `PRONOME_3A`.
+
+É possível dar um ID à regra que corresponda a um exemplo particularmente emblemático da correção executada pela regra. Por exemplo, `DUZENTAS_GRAMAS` é uma regra que corrige o erro de concordância nominal em \**duzent**as** gramas* para *duzent**os** gramas*, mas também se aplica a outros numerais relativos a centenas, como *trezentos*, *quatrocentos*, etc. Tal prática é preferível a dar um ID tecnicamente descritivo mas demasiado longo, como `CONCORDANCIA_NOMINAL_FEMININO_ENTRE_CENTENAS_E_GRAMA_QUE_DEVERIA_SER_MASCULINO` 😱
+
+Sabemos que pode ser um desafio em alguns casos, mas tente manter o ID da regra o mais sucinto possível. Algumas abreviaturas são possíveis, p. ex. `ADJ` em vez de `ADJETIVO`, mas use o bom-senso. <sup>(`TODO`: find PT glossing standards)</sup>
+
+Os IDs das regras, tecnicamente, aceitam qualquer caractere Unicode. Mesmo assim, evite usar letras fora do ASCII, a não ser que a sua regra especificamente esteja corrigindo um erro de acentuação. Por exemplo, `CONFUSAO_INFLUENCIA_INFLUÊNCIA` indica claramente que o problema é entre _influencia_ e _influência_. Note, no entanto, que a palavra `CONFUSAO` não precisa de til.
+
+No fim das contas, lembre-se de que os IDs das regras são arbitrários. Se não for inteiramente possível seguir as sugestões acima, busque redigir uma pequena explicação em seu *pull request* para os revisores.


### PR DESCRIPTION
Basic version has been reviewed and should be ready – it doesn't introduce any craziness and there are no glaring gaps.

A few things to be done later, e.g. adding some links to documentation on commit squashing.