### PR TITLE
[pt] Add documentation on rules

### DIFF
--- a/pt/git.md
+++ b/pt/git.md
@@ -40,6 +40,7 @@ Maus exemplos seriam: `maria_22_de_abril`, `regras`.
 Dentro do possível, mantenha seus *commits* bem descritos:
 - comece todos as suas mensagens de *commit* com a tag `[pt]`;
 - prefira escrevê-las em inglês;
-- a primeira linha da sua mensagem não deve ultrapassar 50 caracteres.
+- a primeira linha da sua mensagem não deve ultrapassar 50 caracteres;
+- a não ser que suas mudanças sejam gerais (ou seja, se apliquem a várias regras), busque pôr o nome da regra na mensagem.
 
-O adágio "*commit early, commit often*" só se aplica ao seu trabalho **local**.
+O adágio "*commit early, commit often*" só se aplica ao seu trabalho **local**. Ao criar um *pull request*, o ideal é que ele seja composto de poucos *commits* razoavelmente completos. Prefira fazer *squash* se você tiver muitos *commits* com mensagens do tipo `"[pt] Fix error"`, `"[pt] Add antipattern"`.

--- a/pt/git.md
+++ b/pt/git.md
@@ -37,10 +37,12 @@ Maus exemplos seriam: `maria_22_de_abril`, `regras`.
 
 ## [Mensagens de *commit*](https://xkcd.com/1296/)
 
+Use [estas diretrizes](https://cbea.ms/git-commit/) (em inglês).
+
 Dentro do possível, mantenha seus *commits* bem descritos:
 - comece todos as suas mensagens de *commit* com a tag `[pt]`;
-- prefira escrevê-las em inglês;
+- escreva-as em inglês;
 - a primeira linha da sua mensagem não deve ultrapassar 50 caracteres;
-- a não ser que suas mudanças sejam gerais (ou seja, se apliquem a várias regras), busque pôr o nome da regra na mensagem.
+- a não ser que suas mudanças sejam gerais (ou seja, se apliquem a várias regras), busque pôr o nome da regra na primeira linha da mensagem.
 
 O adágio "*commit early, commit often*" só se aplica ao seu trabalho **local**. Ao criar um *pull request*, o ideal é que ele seja composto de poucos *commits* razoavelmente completos. Prefira fazer *squash* se você tiver muitos *commits* com mensagens do tipo `"[pt] Fix error"`, `"[pt] Add antipattern"`.

--- a/pt/rules.md
+++ b/pt/rules.md
@@ -1,3 +1,25 @@
 # Regras
 
-mais uma
+Nossa ideia é que contribuintes *opensource* tenham suficiente flexibilidade para sugerir novas regras sem grandes obstáculos de natureza técnica, mas sem pôr em risco a qualidade e consistência das nossas regras. Tendo isso em vista, desenvolvemos as diretrizes nesta página.
+
+## *Rule IDs*
+Os IDs das nossas regras *atuais* não são lá muito coesos. Temos regras com IDs em inglês, outras em português, e ainda outras com as duas línguas misturadas. No momento da redação destas diretrizes, não temos a menor intenção de renomeá-las todas para que combinem com o novo esquema. As regras *legacy* ficam como estão no presente momento, mas isso não quer dizer que não possamos revisar como as nomeamos **a partir de agora**.
+
+### Esquema
+
+O ID de uma regra deve...
+
+- ser escrito **em português**;
+    - sabemos que é uma prática um tanto peculiar, mas isso facilita a identificação dessas regras nos *logs* internos;
+    - se estiver propondo uma regra válida para todos os dialetos do português, na medida do possível evite palavras com grafias que variam de acordo com dialeto – se não for possível, pedimos que use a grafia usada **no Brasil**;
+- ser escrito **em maiúsculas** – ou seja, `NOVA_REGRA`;
+    - cada elemento deve ser separado por um *underscore*, ou seja, `_`;
+- ser informativo – evite IDs arbitrários como `REGRA_PLURAL_2`, `PRONOME_3A`.
+
+É possível dar um ID à regra que corresponda a um exemplo particularmente emblemático da correção executada pela regra. Por exemplo, `DUZENTAS_GRAMAS` é uma regra que corrige o erro de concordância nominal em \**duzent**as** gramas* para *duzent**os** gramas*, mas também se aplica a outros numerais relativos a centenas, como *trezentos*, *quatrocentos*, etc. Tal prática é preferível a dar um ID tecnicamente descritivo mas demasiado longo, como `CONCORDANCIA_NOMINAL_FEMININO_ENTRE_CENTENAS_E_GRAMA_QUE_DEVERIA_SER_MASCULINO` 😱
+
+Sabemos que pode ser um desafio em alguns casos, mas tente manter o ID da regra o mais sucinto possível. Algumas abreviaturas são possíveis, p. ex. `ADJ` em vez de `ADJETIVO`, mas use o bom-senso. <sup>(`TODO`: find PT glossing standards)</sup>
+
+Os IDs das regras, tecnicamente, aceitam qualquer caractere Unicode. Mesmo assim, evite usar letras fora do ASCII, a não ser que a sua regra especificamente esteja corrigindo um erro de acentuação. Por exemplo, `CONFUSAO_INFLUENCIA_INFLUÊNCIA` indica claramente que o problema é entre _influencia_ e _influência_. Note, no entanto, que a palavra `CONFUSAO` não precisa de til.
+
+No fim das contas, lembre-se de que os IDs das regras são arbitrários. Se não for inteiramente possível seguir as sugestões acima, busque redigir uma pequena explicação em seu *pull request* para os revisores.


### PR DESCRIPTION
Mostly just info on rule IDs. I suppose more can be added at some point. Do let me know if you think there's something super basic that you think should be there for the first version.

Ugh, sorry, I messed up and branched off `pt/docs/git` instead of `pt/docs/new`. The only commit here is 4642fcd.

Also I did completely forget that it was *your* task to write this up... oh well. Take the stuff here is my suggestions, use whatever you see fit.