### PR TITLE
Update not to use new English() style constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # languagetool-org
-repo for Github pages
+repo for GitHub pages

--- a/adding-a-new-language.md
+++ b/adding-a-new-language.md
@@ -8,7 +8,7 @@ to write XML rules for a new language, please ask on our
 [forum](https://forum.languagetool.org/). We will help you set up the 
 new language so no programming will be required by you. If you are a 
 developer, fork [LanguageTool on 
-github](https://github.com/languagetool-org/languagetool) and make the 
+GitHub](https://github.com/languagetool-org/languagetool) and make the 
 following changes in your fork. Once you've added enough error 
 detection rules and we've checked your changes, you can send a pull 
 request. Please note that we're only going to add a language to the 
@@ -19,12 +19,12 @@ request.
 
 Note that the changes listed are just the technical changes needed so 
 your language can be selected in LanguageTool. How useful support for 
-the new language will be depends solely on the rules you're going to 
+the new language will depend solely on the rules you're going to 
 write. These rules decide how many errors can actually be found and how 
 many false alarms the system shows. Well-supported languages have more 
 than 1000 rules in LanguageTool.
 
-1. Fork the code [at github](https://github.com/languagetool-org/languagetool).
+1. Fork the code [at GitHub](https://github.com/languagetool-org/languagetool).
 2. Clone your forked repository.
 3. Switch to the `languagetool-language-modules` directory.
 4. Create a new project using Maven: `mvn archetype:generate -DgroupId=org.languagetool -DartifactId=**xy** -DarchetypeArtifactId=maven-archetype-quickstart -DinteractiveMode=false` (replace xy with the [ISO 639-1 Code](http://www.loc.gov/standards/iso639-2/php/code_list.php) of your language).

--- a/code-style.md
+++ b/code-style.md
@@ -23,6 +23,13 @@ settings](https://raw.githubusercontent.com/languagetool-org/languagetool/master
   with `x.y` being the version number of the next release.
 * Add `@Nullable` to methods that might return `null`, no matter if 
   these methods are public or not.
+* Do not share same package path among submodules/subprojects, 
+  ex. between `language-en` and `language-core`. It is known as `split package`
+  problem that prevent a migration for Java Platform Module System (JPMS)
+  introduced in Java 9. Each individual language module should have its own
+  and unique package path which will end with a language code,
+  ex. `org.languagetool.language.en` and `org.languagetool.language.rules.en`
+  for English language project.
 
 Examples for proper use of whitespace:
 

--- a/how-to-add-a-new-committer.md
+++ b/how-to-add-a-new-committer.md
@@ -4,7 +4,7 @@ This is our internal workflow documentation for how to add a new committer.
 
 * if someone sends more than two good patches (no matter if code or 
   rules), offer them commit access
-* add them as a team member on github
+* add them as a team member on GitHub
 * ask them to follow the instructions on
   <http://dev.languagetool.org/tips-for-new-committers>  
 * welcome them on the forum and twitter

--- a/java-api.md
+++ b/java-api.md
@@ -26,7 +26,7 @@ that to check your text. Also see [the API documentation (Javadoc)](http://langu
 For example:
 
 ```java
-    JLanguageTool langTool = new JLanguageTool(new BritishEnglish());
+    JLanguageTool langTool = new JLanguageTool(Languages.getLanguageForName("English (GB)"));
     // comment in to use statistical ngram data:
     //langTool.activateLanguageModelRules(new File("/data/google-ngram-data"));
     List<RuleMatch> matches = langTool.check("A sentence with a error in the Hitchhiker's Guide tot he Galaxy");
@@ -52,7 +52,7 @@ that accepts the `AnnotatedText` object.
 ## Multi-Threading
 
 The `JLanguageTool` class is not thread safe. Create one instance of `JLanguageTool`
-per thread, but create the language only once (e.g. `new BritishEnglish()`) and
+per thread, but create the language only once (e.g. `Languages.getLanguageByName("English (GB)")`) and
 use that for all instances of `JLanguageTool`. The same is true for
 `MultiThreadedJLanguageTool` - its name refers to the fact that it uses
 threads internally, but it's not thread safe itself.
@@ -61,14 +61,14 @@ threads internally, but it's not thread safe itself.
 
 If you want spell checking and the language you're working with has variants,
 you will need to specify that variant in the `JLanguageTool` constructor, e.g.
-`new AmericanEnglish()` instead of just `new English()`.
+`Languages.getLanguageByName("English (US)")` instead of `Languages.getLanguageByName("English")`.
 
 To ignore words, i.e. exclude them from spell checking, call the `addIgnoreTokens(...)`
 method of the spell checking rule you're using. You first have to find the rule by
 iterating over all active rules. Example:
 
 ```java
-    JLanguageTool lt = new JLanguageTool(new AmericanEnglish());
+    JLanguageTool lt = new JLanguageTool(Langauges.getLanguageByName("English (US)")));
     for (Rule rule : lt.getAllActiveRules()) {
       if (rule instanceof SpellingCheckRule) {
         List<String> wordsToIgnore = Arrays.asList("specialword", "myotherword");
@@ -93,9 +93,9 @@ LanguageTool determines which languages it supports at runtime by reading
 them from a file `META-INF/org/languagetool/language-module.properties`
 in the classpath. The file may look like this:
 
-    languageClasses=org.languagetool.language.Italian
-    languageClasses=org.languagetool.language.Polish
-    languageClasses=org.languagetool.language.English,org.languagetool.language.AmericanEnglish
+    languageClasses=org.languagetool.language.it.Italian
+    languageClasses=org.languagetool.language.pl.Polish
+    languageClasses=org.languagetool.language.en.English,org.languagetool.language.en.AmericanEnglish
 
 You either build that file yourself, adapted to the languages you support, or you
 take it from the LanguageTool stand-alone distribution. Of course, the classes

--- a/java-api.md
+++ b/java-api.md
@@ -26,7 +26,7 @@ that to check your text. Also see [the API documentation (Javadoc)](http://langu
 For example:
 
 ```java
-    JLanguageTool langTool = new JLanguageTool(Languages.getLanguageForName("English (GB)"));
+    JLanguageTool langTool = new JLanguageTool(Languages.getLanguageForShortCode("en-GB"));
     // comment in to use statistical ngram data:
     //langTool.activateLanguageModelRules(new File("/data/google-ngram-data"));
     List<RuleMatch> matches = langTool.check("A sentence with a error in the Hitchhiker's Guide tot he Galaxy");
@@ -52,7 +52,7 @@ that accepts the `AnnotatedText` object.
 ## Multi-Threading
 
 The `JLanguageTool` class is not thread safe. Create one instance of `JLanguageTool`
-per thread, but create the language only once (e.g. `Languages.getLanguageByName("English (GB)")`) and
+per thread, but create the language only once (e.g. `Languages.getLanguageForShortCode("en-GB")`) and
 use that for all instances of `JLanguageTool`. The same is true for
 `MultiThreadedJLanguageTool` - its name refers to the fact that it uses
 threads internally, but it's not thread safe itself.
@@ -61,14 +61,14 @@ threads internally, but it's not thread safe itself.
 
 If you want spell checking and the language you're working with has variants,
 you will need to specify that variant in the `JLanguageTool` constructor, e.g.
-`Languages.getLanguageByName("English (US)")` instead of `Languages.getLanguageByName("English")`.
+`Languages.getLanguageForShortCode("en-US")` instead of `Languages.getLanguageForShortCode("en")`.
 
 To ignore words, i.e. exclude them from spell checking, call the `addIgnoreTokens(...)`
 method of the spell checking rule you're using. You first have to find the rule by
 iterating over all active rules. Example:
 
 ```java
-    JLanguageTool lt = new JLanguageTool(Langauges.getLanguageByName("English (US)")));
+    JLanguageTool lt = new JLanguageTool(Langauges.getLanguageForShortCode("en-US")));
     for (Rule rule : lt.getAllActiveRules()) {
       if (rule instanceof SpellingCheckRule) {
         List<String> wordsToIgnore = Arrays.asList("specialword", "myotherword");


### PR DESCRIPTION
# Motivation

[A pull-request to support JPMS](https://github.com/languagetool-org/languagetool/pull/9406) will change package paths.
A dev document should help developers to be able to migrate smoothly.

# Changes

- Recommend `getLanguageBy*` method When LanguageTool supports Java Platform Module System introduced in Java 9, all the language classes should be changed its package path. In order to help users migration smoother, dev document recommends to use Languages.getLanguageBy* utility methods to create Language object in java-api.md.
 - Explain split package problem in code-style.md
 - Spell of GitHub trademark