### PR TITLE
Update http-server.md for OSX

### DIFF
--- a/http-server.md
+++ b/http-server.md
@@ -18,6 +18,10 @@ Download the [LanguageTool Desktop version for offline use](https://languagetool
 users](https://languagetool.org/business).
   * The [Windows](https://languagetool.org/windows) and [Mac](https://languagetool.org/mac) desktop apps will not work with this approach.
 
+On MacOS you can install the server using [brew](https://github.com/Homebrew/brew):
+
+    brew install languagetool
+
 ### Starting from Command Line
 
 The next three steps are optional but strongly recommended on Linux and Mac for 
@@ -47,7 +51,7 @@ for Arch Linux:
 
 On MacOS you can start the server using [brew](https://github.com/Homebrew/brew):
 
-    brew services start languagetool
+    languagetool-server --config server.properties --port 8081 --allow-origin "*"
 
 * If this fails with an error saying that `java` cannot be found,
   [install Java 8 or later](https://java.com/en/download/help/download_options.xml) first.


### PR DESCRIPTION
The current docs didn't work for me

- Why is brew mentioned below ("...start service") but not mentioned on the top-part when it's about installation?
- The mentioned brew service is running but localhost doesn't show anything
- This helped: https://github.com/languagetool-org/languagetool/issues/3719
   Using the languagetool-server command everythin runs as described

This might all be my fault but I couldn't find a solution in the main repo or in the docs.
Happy to adjust and improve this!