### PR TITLE
Add Eloquent to the list of applications

### DIFF
--- a/software-that-supports-languagetool-as-a-plug-in-or-add-on.md
+++ b/software-that-supports-languagetool-as-a-plug-in-or-add-on.md
@@ -31,6 +31,7 @@ this software is not supported by the LanguageTool team.**
 * [TeXtidote](https://github.com/sylvainhalle/textidote), a correction tool for LaTeX documents and other formats.  Other ways to [check LaTeX](https://dev.languagetool.org/checking-la-tex-with-languagetool).  
 * [vim-LanguageTool](https://github.com/dpelle/vim-LanguageTool)
 * [vim-grammarous](https://github.com/rhysd/vim-grammarous)
+* [Eloquent Linux application](https://flathub.org/apps/re.sonny.Eloquent)
 
 
 ## Archive


### PR DESCRIPTION
Hello LanguageTool team,

I made this

* https://github.com/sonnyp/Eloquent
* https://flathub.org/apps/re.sonny.Eloquent
* https://blog.sonny.re/eloquent-proofreading-assistant
* https://floss.social/@sonny/114020107205199107

I tried my best to credit LanguageTool but let me know if I can improve that. 