### PR TITLE
VSCode extension: Switch from LTeX to LTeX+

### DIFF
--- a/checking-la-tex-with-languagetool.md
+++ b/checking-la-tex-with-languagetool.md
@@ -6,5 +6,5 @@ recommend using external tools.
 * Use [Overleaf](https://overleaf.com) with [our browser add-on](https://languagetool.org/addon-redirect)
 * [TeXtidote](https://sylvainhalle.github.io/textidote/)
 * [TeXstudio](http://texstudio.sourceforge.net/)
-* [LTEX Extension for VS Code](https://github.com/valentjn/vscode-ltex#ltex-extension-for-vs-code-grammarspell-checker-with-languagetool-and-latex-support)
+* [LTEX+ Extension for VS Code](https://ltex-plus.github.io/ltex-plus)
 * [YaLafi: Yet another LaTeX filter](https://github.com/matze-dd/YaLafi)

--- a/software-that-supports-languagetool-as-a-plug-in-or-add-on.md
+++ b/software-that-supports-languagetool-as-a-plug-in-or-add-on.md
@@ -27,7 +27,7 @@ this software is not supported by the LanguageTool team.**
 * [LanguageTool for Thunderbird](https://addons.thunderbird.net/thunderbird/addon/grammar-and-spell-checker/)
 * [LanguageTool for vim](http://www.vim.org/scripts/script.php?script_id=3223)
 * [pyLanguagetool](https://github.com/Findus23/pyLanguagetool), command-line tool for using the JSON API
-* [LTeX Extension for VS Code (Visual Studio Code)](https://valentjn.github.io/ltex/), Grammar/Spell Checker with LanguageTool and LaTeX Support. Other ways to [check LaTeX](https://dev.languagetool.org/checking-la-tex-with-languagetool).
+* [LTeX+ Extension for VS Code (Visual Studio Code)](https://ltex-plus.github.io/ltex-plus), Grammar/Spell Checker Using LanguageTool with Support for LaTeX, Markdown, and Others. Other ways to [check LaTeX](https://dev.languagetool.org/checking-la-tex-with-languagetool).
 * [TeXtidote](https://github.com/sylvainhalle/textidote), a correction tool for LaTeX documents and other formats.  Other ways to [check LaTeX](https://dev.languagetool.org/checking-la-tex-with-languagetool).  
 * [vim-LanguageTool](https://github.com/dpelle/vim-LanguageTool)
 * [vim-grammarous](https://github.com/rhysd/vim-grammarous)
@@ -51,3 +51,4 @@ Add-ons that haven't been updated for quite some time and that seem to be **unma
 * [LanguageTool for Oxygen XML editor](https://github.com/danielnaber/oxygen-languagetool-plugin)
 * [LanguageTool for TinyMCE 4](https://github.com/KnowZero/tinymce4-languagetool) (experimental)
 * [LanguageTool for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=adamvoss.vscode-languagetool) ([source code](https://github.com/adamvoss/vscode-languagetool))
+* [LTeX Extension for VS Code (Visual Studio Code)](https://valentjn.github.io/ltex/), Grammar/Spell Checker with LanguageTool and LaTeX Support. 


### PR DESCRIPTION
The LTeX extension seems to be unmaintend. [Last Update in 2021](https://marketplace.visualstudio.com/items?itemName=valentjn.vscode-ltex) and last commits in the [GitHub repository](https://github.com/valentjn/vscode-ltex) in 2023. LTeX+ is fork of it. 

From the [README of LTeX+](https://github.com/ltex-plus/vscode-ltex-plus/blob/3976ac9b054912be2986f9c06687e91cd6d71e86/README.md):
> Until version 13.1.0, Julian Valentin developed LTEX+ as [LTEX](https://github.com/valentjn/vscode-ltex). LTEX is a fork of the abandoned [LanguageTool for Visual Studio Code extension](https://github.com/adamvoss/vscode-languagetool). This extension would not have been possible without the work of Adam Voss† and Julian Valentin.