### PR TITLE
fix: Add Zettlr to list of supporting software

### DIFF
--- a/software-that-supports-languagetool-as-a-plug-in-or-add-on.md
+++ b/software-that-supports-languagetool-as-a-plug-in-or-add-on.md
@@ -32,7 +32,7 @@ this software is not supported by the LanguageTool team.**
 * [vim-LanguageTool](https://github.com/dpelle/vim-LanguageTool)
 * [vim-grammarous](https://github.com/rhysd/vim-grammarous)
 * [Eloquent Linux application](https://flathub.org/apps/re.sonny.Eloquent)
-
+* [Zettlr](https://www.zettlr.com/)
 
 ## Archive
 


### PR DESCRIPTION
This PR adds Zettlr to the list of supporting software that can work with LanguageTool.